### PR TITLE
Errors are not exported.

### DIFF
--- a/lib/jayschema.js
+++ b/lib/jayschema.js
@@ -39,6 +39,8 @@ JaySchema.loaders = {
   http: require('./httpLoader.js')
 };
 
+JaySchema.errors = Errors;
+
 // ******************************************************************
 // Get an array of $refs for which we don’t have a schema yet.
 // ******************************************************************


### PR DESCRIPTION
Hi Nate,

I want to write a custom schema loader for JaySchema. In the example `httpLoader`, you use the error objects from `errors.js`, which is not exported by the module itself. I added a `errors` object to `JaySchema`, so I can write my own schema loader.

Or do I have to provide my own errors?

Regards, Paul
