### PR TITLE
Support 'function' data type

### DIFF
--- a/lib/suites/draft-04/core.js
+++ b/lib/suites/draft-04/core.js
@@ -36,18 +36,17 @@ exports.jsonEqual = jsonEqual;
 // ******************************************************************
 function apparentType(val) {
   switch (typeof val) {
-    case 'boolean':
-    case 'string':
-      return typeof val;
+    case 'object':
+      if (val === null) { return 'null'; }
+      if (Array.isArray(val)) { return 'array'; }
+      return 'object';
 
     case 'number':
       if (val % 1 === 0) { return 'integer'; }
       return 'number';
 
     default:
-      if (val === null) { return 'null'; }
-      if (Array.isArray(val)) { return 'array'; }
-      return 'object';
+      return typeof val;
   }
 }
 exports.apparentType = apparentType;

--- a/tests/apparentType.js
+++ b/tests/apparentType.js
@@ -24,6 +24,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(null).should.not.equal('array');
       core.apparentType({foo: [1, 2, 3]}).should.not.equal('array');
       core.apparentType('hello world').should.not.equal('array');
+      core.apparentType(function(){}).should.not.equal('array');
     });
   });
 
@@ -43,6 +44,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(null).should.not.equal('boolean');
       core.apparentType({foo: [1, 2]}).should.not.equal('boolean');
       core.apparentType('hello world').should.not.equal('boolean');
+      core.apparentType(function(){}).should.not.equal('boolean');
     });
   });
 
@@ -61,6 +63,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(null).should.not.equal('integer');
       core.apparentType({foo: [1, 2]}).should.not.equal('integer');
       core.apparentType('hello world').should.not.equal('integer');
+      core.apparentType(function(){}).should.not.equal('integer');
     });
   });
 
@@ -78,6 +81,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(null).should.not.equal('number');
       core.apparentType({foo: [1, 2, 3]}).should.not.equal('number');
       core.apparentType('hello world').should.not.equal('number');
+      core.apparentType(function(){}).should.not.equal('number');
     });
   });
 
@@ -95,6 +99,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(42.1).should.not.equal('null');
       core.apparentType({foo: [1, 2, 3]}).should.not.equal('null');
       core.apparentType('hello world').should.not.equal('null');
+      core.apparentType(function(){}).should.not.equal('null');
     });
   });
 
@@ -115,6 +120,7 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(42.1).should.not.equal('object');
       core.apparentType(null).should.not.equal('object');
       core.apparentType('hello world').should.not.equal('object');
+      core.apparentType(function(){}).should.not.equal('object');
     });
 
     it('should not mistake null or Array for "object"', function() {
@@ -137,6 +143,26 @@ describe('Core § 3.5 JSON Schema primitive types:', function() {
       core.apparentType(42.1).should.not.equal('string');
       core.apparentType(null).should.not.equal('string');
       core.apparentType({foo: 'hello'}).should.not.equal('string');
+      core.apparentType(function(){}).should.not.equal('string');
+    });
+  });
+
+  describe('function:', function() {
+    it('should return "function"', function() {
+      core.apparentType(function(){}).should.equal('function');
+      core.apparentType([].map).should.equal('function');
+    });
+
+    it ('should not return "function" for non-function types', function() {
+      core.apparentType([true, false]).should.not.equal('function');
+      core.apparentType(true).should.not.equal('function');
+      core.apparentType(false).should.not.equal('function');
+      core.apparentType(0).should.not.equal('function');
+      core.apparentType(42).should.not.equal('function');
+      core.apparentType(42.1).should.not.equal('function');
+      core.apparentType(null).should.not.equal('function');
+      core.apparentType({foo: [1, 2]}).should.not.equal('function');
+      core.apparentType('hello world').should.not.equal('function');
     });
   });
 });


### PR DESCRIPTION
Now I know what you're gonna say.  Functions aren't valid json.  Bear with me.

JSON schemas are really useful, and shouldn't be limited to just strict JSON cases.  If you add in the capability to detect functions, you've now got support for all javascript types and therefore have broadened the usefulness.

This doesn't interfere with any of the existing capabilities, as you can see.  The tests all still pass, and I've added a few more.  There a couple possible cases to consider:
1. The user of the library doesn't have functions in their target JSON, or their schema.  Great, everything will work as according to spec.
2. The user of the library has functions in their target JSON, but not in the schema.  Type checks still work as normal, so if you're expecting an object and you get a function, the schema validation will fail.  This is actually an _increase_ in accuracy, since with the previous implementation this 'function' would have been detected as an 'object' and the test would pass.
3. The user has functions in their schema, but not in the JSON.  This should be the same as the previous case.  Type checking still works as normal.

What do you say?  Can we have our cake and eat it too?
