### PR TITLE
Support instances without hasOwnProperty method

### DIFF
--- a/lib/suites/draft-04/keywords/dependencies.js
+++ b/lib/suites/draft-04/keywords/dependencies.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
   var depsToApply = [];
   for (i = 0, len = deps.length; i !== len; ++i) {
     prop = deps[i];
-    if (config.inst.hasOwnProperty(prop)) { depsToApply.push(prop); }
+    if (Object.prototype.hasOwnProperty.call(config.inst, prop)) { depsToApply.push(prop); }
   }
 
   for (var index = 0; index < depsToApply.length; ++index) {
@@ -27,7 +27,7 @@ module.exports = function(config) {
       var missing = [];
       for (i = 0, len = dep.length; i !== len; ++i) {
         prop = dep[i];
-        if (!config.inst.hasOwnProperty(prop)) { missing.push(prop); }
+        if (!Object.prototype.hasOwnProperty.call(config.inst, prop)) { missing.push(prop); }
       }
 
       if (missing.length) {

--- a/lib/suites/draft-04/keywords/required.js
+++ b/lib/suites/draft-04/keywords/required.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
   var missing = [];
   for (var i = 0, len = config.schema.required.length; i !== len; ++i) {
     var prop = config.schema.required[i];
-    if (!config.inst.hasOwnProperty(prop)) { missing.push(prop); }
+    if (!Object.prototype.hasOwnProperty.call(config.inst, prop)) { missing.push(prop); }
   }
 
   if (missing.length) {


### PR DESCRIPTION
A validation subject is not necessarily derived from `Object`, and thus might lack `hasOwnProperty`.
