### PR TITLE
Caches validator functions in hot path

### DIFF
--- a/lib/suites/draft-04/index.js
+++ b/lib/suites/draft-04/index.js
@@ -24,6 +24,10 @@ var PROPS_TO_VALIDATE = {
   string: ['maxLength', 'minLength', 'pattern', 'format']
 };
 
+var VALIDATOR_FUNCTIONS = {
+  type: require('./keywords/type.js')
+};
+
 // ******************************************************************
 // Return a set of tests to apply to the instance.
 // ******************************************************************
@@ -115,14 +119,17 @@ function run(config)
   if (Object.keys(config.schema).length === 0) { return errors; }
 
   // validate the type: if it isn't valid we can bail early
-  errors = errors.concat(require('./keywords/type.js')(config));
+  errors = errors.concat(VALIDATOR_FUNCTIONS.type(config));
   if (errors.length) { return errors; }
 
   // test all applicable schema properties
   var props = getApplicableTests(config);
   for (var index = 0; index < props.length; ++index) {
     var prop = props[index];
-    var fn = require('./keywords/' + prop + '.js');
+    var fn = VALIDATOR_FUNCTIONS[prop];
+    if (!fn) {
+      fn = VALIDATOR_FUNCTIONS[prop] = require('./keywords/' + prop + '.js');
+    }
     errors = errors.concat(fn(config));
   }
   return errors;


### PR DESCRIPTION
A lot of validation time is being spent in `require`. Though there is a require cache for the actual loading of the required file, the pathname still needs to be resolved and validated when requiring a relative path.

Caching the validator functions immediately gave me a 5-6x speedup on a small micro-benchmark I put together, but it will easily give bigger speedups with more complex objects.

```
before x 288 ops/sec ±2.35% (83 runs sampled)
after x 1,609 ops/sec ±2.30% (88 runs sampled)
```