### PR TITLE
cache dynamic require lookups

### DIFF
--- a/lib/suites/draft-04/index.js
+++ b/lib/suites/draft-04/index.js
@@ -28,6 +28,17 @@ var VALIDATOR_FUNCTIONS = {
   type: require('./keywords/type.js')
 };
 
+var requireCache = {};
+
+function cacheOrRequire(module) {
+  if (requireCache.hasOwnProperty(module)) {
+    return requireCache[module];
+  }
+
+  var module = requireCache[module] = require(module);
+  return module;
+}
+
 // ******************************************************************
 // Return a set of tests to apply to the instance.
 // ******************************************************************
@@ -128,7 +139,8 @@ function run(config)
     var prop = props[index];
     var fn = VALIDATOR_FUNCTIONS[prop];
     if (!fn) {
-      fn = VALIDATOR_FUNCTIONS[prop] = require('./keywords/' + prop + '.js');
+      fn = VALIDATOR_FUNCTIONS[prop] =
+        cacheOrRequire('./keywords/' + prop + '.js');
     }
     errors = errors.concat(fn(config));
   }


### PR DESCRIPTION
The require algorithm in node is heavy. Every time you call it, it resolves the require path for you. Here I am caching the require statements to prevent this performance penalty, but really all dynamic requires should be removed.
