### PR TITLE
Workaround for OpenAPI / Swagger v2 schema validation

### DIFF
--- a/lib/schemaRegistry.js
+++ b/lib/schemaRegistry.js
@@ -104,7 +104,10 @@ SchemaRegistry._gatherRefs = function(obj) {
   do {
 
     if (Object.prototype.hasOwnProperty.call(currentObj, '$ref')) {
-      result.push(currentObj.$ref);
+      var currentObjRef = currentObj.$ref;
+      if ( typeof currentObjRef === "string" ) {
+        result.push(currentObj.$ref);
+      }
     }
 
     var keys = Object.keys(currentObj);


### PR DESCRIPTION
Hi Nate,

Currently jayschema does not validate document instances of OpenAPI / Swagger v2
schemas which is a valid JSON Schema Draft 4 specification. jayschema **does** correctly
validate the schema itself, but fails subsequently for instance validation against that schema as follows:

```
  if (uri.slice(0, 4).toLowerCase() === 'urn:') {
          ^

TypeError: uri.slice is not a function
    at Object.parse (/path/to/jayschema/lib/uri.js:18:11)
    at null.<anonymous> (/path/to/jayschema/lib/schemaRegistry.js:180:24)
    at Array.forEach (native)
    at SchemaRegistry._missingRefsForSchema (/path/to/jayschema/lib/schemaRegistry.js:178:11)
    at SchemaRegistry.register (/path/to/jayschema/lib/schemaRegistry.js:224:22)
    at JaySchema.register (/path/to/jayschema/lib/jayschema.js:74:40)
    at JaySchema.validate (/path/to/jayschema/lib/jayschema.js:255:8)
    at Object.<anonymous> (/path/to/jayschema/before.js:12:4)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
```

This is due to declarations of the following form in the Schema for Swagger v2:

``` json
    "$ref": {
      "type": "string"
    }
```

Which themselves are working around lack of references in Json Schema Draft 4 for
'$ref' itself. Declaring `$ref` as type string ( for which there is also no declaration
in the Json Schema Draft4 Schema ) seems reasonable.

This PR patches `lib/schemaRegistry._gatherRefs` to detect this pattern of use and
skip adding it to the gathered references. By so doing, it allows the usage of '$ref' in schema
documents, and validation against in document instances.

``` javascript
var JaySchema = require('.')
var js = new JaySchema()

// curl -o - https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json > petstore.json
// curl -o - https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v2.0/schema.json > swagger.json

var JsonSchemaDraft4 = require('./lib/suites/draft-04/json-schema-draft-v4.json');
var SwaggerV2 = require('./swagger.json')
var Petstore = require('./petstore.json')

// Validate Schema for Open API Specification ( Swagger v2 )
js.validate(SwaggerV2, JsonSchemaDraft4, function(errs) {
  if (errs) console.log("Errors in Schema");
  else console.log("Valid Json Schema Draft 4 Schema");
})

// Validate instance schema
js.validate(Petstore, SwaggerV2, function(errs) {
  if (errs) console.log("Errors in Instance");
  else console.log("Valid Open API Schema Instance");
})
```

Submitting a PR in the hopes that it is a useful workaround/fix for anyone writing or
using schema documents that define and use '$ref' in accordance with the intended
use in Json Schema itself.
